### PR TITLE
Fix Issue #8 When setting a value in xaml (binding or manual), increase no longer works.

### DIFF
--- a/source/NumericUpDownLib/Base/AbstractBaseUpDown.xaml.cs
+++ b/source/NumericUpDownLib/Base/AbstractBaseUpDown.xaml.cs
@@ -909,7 +909,7 @@ namespace NumericUpDownLib.Base
 			{
 			}
 
-			return control.MaxValue;
+			return control.Value;
 		}
 
 		private static void OnValueChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
@@ -920,6 +920,8 @@ namespace NumericUpDownLib.Base
 			{
 				RoutedPropertyChangedEventArgs<T> e = new RoutedPropertyChangedEventArgs<T>((T)args.OldValue, (T)args.NewValue, ValueChangedEvent);
 				control.OnValueChanged(e);
+
+				AbstractBaseUpDown<T>.CoerceValue(obj, args.NewValue);
 			}
 		}
 		#endregion Value dependency property helper methods
@@ -943,8 +945,7 @@ namespace NumericUpDownLib.Base
 				RoutedPropertyChangedEventArgs<T> e = new RoutedPropertyChangedEventArgs<T>((T)args.OldValue, (T)args.NewValue, MinValueChangedEvent);
 				control.OnMinValueChanged(e);
 
-				control.CoerceValue(MaxValueProperty);
-				control.CoerceValue(ValueProperty);
+				AbstractBaseUpDown<T>.CoerceMinValue(obj, args.NewValue);
 			}
 		}
 
@@ -988,7 +989,7 @@ namespace NumericUpDownLib.Base
 				RoutedPropertyChangedEventArgs<T> e = new RoutedPropertyChangedEventArgs<T>((T)args.OldValue, (T)args.NewValue, MaxValueChangedEvent);
 				control.OnMaxValueChanged(e);
 
-				control.CoerceValue(ValueProperty);
+				AbstractBaseUpDown<T>.CoerceMaxValue(obj, args.NewValue);
 			}
 		}
 

--- a/source/NumericUpDownLib/ByteUpDown.cs
+++ b/source/NumericUpDownLib/ByteUpDown.cs
@@ -44,15 +44,18 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(ByteUpDown),
 					   new FrameworkPropertyMetadata(typeof(ByteUpDown)));
 
-			////            MaxValueProperty.OverrideMetadata(typeof(ByteUpDown),
-			////                                                  new PropertyMetadata(byte.MaxValue));
+			MaxValueProperty.OverrideMetadata(typeof(ByteUpDown),
+			                                      new PropertyMetadata(byte.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(ByteUpDown),
+												  new PropertyMetadata(byte.MinValue));
 
 			// Override Min/Max default values
-			////            AbstractBaseUpDown<byte>.MinValueProperty.OverrideMetadata(
-			////                typeof(ByteUpDown), new PropertyMetadata(byte.MinValue));
-			////
-			////            AbstractBaseUpDown<byte>.MaxValueProperty.OverrideMetadata(
-			////                typeof(ByteUpDown), new PropertyMetadata(byte.MaxValue));
+////		AbstractBaseUpDown<byte>.MinValueProperty.OverrideMetadata(
+////		    typeof(ByteUpDown), new PropertyMetadata(byte.MinValue));
+////		
+////		AbstractBaseUpDown<byte>.MaxValueProperty.OverrideMetadata(
+////		    typeof(ByteUpDown), new PropertyMetadata(byte.MaxValue));
 		}
 
 		/// <summary>

--- a/source/NumericUpDownLib/DecimalUpDown.cs
+++ b/source/NumericUpDownLib/DecimalUpDown.cs
@@ -45,6 +45,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(DecimalUpDown),
 					   new FrameworkPropertyMetadata(typeof(DecimalUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(DecimalUpDown),
+												  new PropertyMetadata(decimal.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(DecimalUpDown),
+												  new PropertyMetadata(decimal.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<decimal>.MinValueProperty.OverrideMetadata(
 			////                typeof(DecimalUpDown), new PropertyMetadata(decimal.MinValue));

--- a/source/NumericUpDownLib/DoubleUpDown.cs
+++ b/source/NumericUpDownLib/DoubleUpDown.cs
@@ -48,6 +48,12 @@ namespace NumericUpDownLib
 			FormatStringProperty.OverrideMetadata(typeof(DoubleUpDown),
 												  new PropertyMetadata("F2"));
 
+			MaxValueProperty.OverrideMetadata(typeof(DoubleUpDown),
+												  new PropertyMetadata(double.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(DoubleUpDown),
+												  new PropertyMetadata(double.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<double>.MinValueProperty.OverrideMetadata(
 			////                typeof(DoubleUpDown), new PropertyMetadata(double.MinValue));

--- a/source/NumericUpDownLib/FloatUpDown.cs
+++ b/source/NumericUpDownLib/FloatUpDown.cs
@@ -47,6 +47,12 @@ namespace NumericUpDownLib
 			FormatStringProperty.OverrideMetadata(typeof(FloatUpDown),
 												  new PropertyMetadata("F2"));
 
+			MaxValueProperty.OverrideMetadata(typeof(FloatUpDown),
+												  new PropertyMetadata(float.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(FloatUpDown),
+												  new PropertyMetadata(float.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<float>.MinValueProperty.OverrideMetadata(
 			////                typeof(FloatUpDown), new PropertyMetadata(float.MinValue));

--- a/source/NumericUpDownLib/LongUpDown.cs
+++ b/source/NumericUpDownLib/LongUpDown.cs
@@ -44,6 +44,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(LongUpDown),
 					   new FrameworkPropertyMetadata(typeof(LongUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(LongUpDown),
+												  new PropertyMetadata(long.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(LongUpDown),
+												  new PropertyMetadata(long.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<long>.MinValueProperty.OverrideMetadata(
 			////                typeof(LongUpDown), new PropertyMetadata(long.MinValue));

--- a/source/NumericUpDownLib/NumericUpDown.cs
+++ b/source/NumericUpDownLib/NumericUpDown.cs
@@ -44,6 +44,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(NumericUpDown),
 					   new FrameworkPropertyMetadata(typeof(NumericUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(NumericUpDown),
+												  new PropertyMetadata(int.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(NumericUpDown),
+												  new PropertyMetadata(int.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<int>.MinValueProperty.OverrideMetadata(
 			////                typeof(NumericUpDown), new PropertyMetadata(int.MinValue));

--- a/source/NumericUpDownLib/SByteUpDown.cs
+++ b/source/NumericUpDownLib/SByteUpDown.cs
@@ -65,6 +65,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(SByteUpDown),
 					   new FrameworkPropertyMetadata(typeof(SByteUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(SByteUpDown),
+												  new PropertyMetadata(sbyte.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(SByteUpDown),
+												  new PropertyMetadata(sbyte.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<sbyte>.MinValueProperty.OverrideMetadata(
 			////                typeof(SByteUpDown), new PropertyMetadata(sbyte.MinValue));

--- a/source/NumericUpDownLib/ShortUpDown.cs
+++ b/source/NumericUpDownLib/ShortUpDown.cs
@@ -44,6 +44,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(ShortUpDown),
 					   new FrameworkPropertyMetadata(typeof(ShortUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(ShortUpDown),
+												  new PropertyMetadata(short.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(ShortUpDown),
+												  new PropertyMetadata(short.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<short>.MinValueProperty.OverrideMetadata(
 			////                typeof(ShortUpDown), new PropertyMetadata(short.MinValue));

--- a/source/NumericUpDownLib/UIntegerUpDown.cs
+++ b/source/NumericUpDownLib/UIntegerUpDown.cs
@@ -44,6 +44,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(UIntegerUpDown),
 					   new FrameworkPropertyMetadata(typeof(UIntegerUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(UIntegerUpDown),
+												  new PropertyMetadata(uint.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(UIntegerUpDown),
+												  new PropertyMetadata(uint.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<uint>.MinValueProperty.OverrideMetadata(
 			////                typeof(UIntegerUpDown), new PropertyMetadata(uint.MinValue));

--- a/source/NumericUpDownLib/ULongUpDown.cs
+++ b/source/NumericUpDownLib/ULongUpDown.cs
@@ -44,6 +44,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(ULongUpDown),
 					   new FrameworkPropertyMetadata(typeof(ULongUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(ULongUpDown),
+												  new PropertyMetadata(ulong.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(ULongUpDown),
+												  new PropertyMetadata(ulong.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<ulong>.MinValueProperty.OverrideMetadata(
 			////                typeof(ULongUpDown), new PropertyMetadata(ulong.MinValue));

--- a/source/NumericUpDownLib/UShortUpDown.cs
+++ b/source/NumericUpDownLib/UShortUpDown.cs
@@ -44,6 +44,12 @@ namespace NumericUpDownLib
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(UShortUpDown),
 					   new FrameworkPropertyMetadata(typeof(UShortUpDown)));
 
+			MaxValueProperty.OverrideMetadata(typeof(UShortUpDown),
+												  new PropertyMetadata(ushort.MaxValue));
+
+			MinValueProperty.OverrideMetadata(typeof(UShortUpDown),
+												  new PropertyMetadata(ushort.MinValue));
+
 			// Override Min/Max default values
 			////            AbstractBaseUpDown<ushort>.MinValueProperty.OverrideMetadata(
 			////                typeof(UShortUpDown), new PropertyMetadata(ushort.MinValue));


### PR DESCRIPTION
Reviewed Coerce methods in AbstractBaseUpDown and inserted OverrideMetadata in control classes for MaxValue and MinValue dps.

https://github.com/Dirkster99/NumericUpDownLib/issues/8