### PR TITLE
Do not clear focus when the control change its visibility and its not focused.

### DIFF
--- a/source/NumericUpDownLib/Base/AbstractBaseUpDown.cs
+++ b/source/NumericUpDownLib/Base/AbstractBaseUpDown.cs
@@ -531,7 +531,11 @@ namespace NumericUpDownLib.Base
 		{
 			Dispatcher.BeginInvoke(DispatcherPriority.ContextIdle, new Action(delegate ()
 			{
-				Keyboard.ClearFocus();
+				if (this.IsKeyboardFocused)
+				{
+					Keyboard.ClearFocus();
+				}
+
 				_objMouseIncr = null;
 			}));
 		}


### PR DESCRIPTION
I've added a check to avoid clear the Keyboard focus when an updown control visibility change.