### PR TITLE
fix: the cursor will focus to the PART_Measuring_Element by mistake

### DIFF
--- a/source/NumericUpDownLib/Base/InputBaseUpDown.xaml
+++ b/source/NumericUpDownLib/Base/InputBaseUpDown.xaml
@@ -34,6 +34,7 @@
 								<TextBox
 									x:Name="PART_Measuring_Element"
 									Margin="0,0,1,0"
+									IsEnabled="False"
 									HorizontalAlignment="Stretch"
 									VerticalAlignment="Stretch"
 									HorizontalContentAlignment="Right"
@@ -50,7 +51,8 @@
 									x:Name="PART_TextBox"
 									Margin="1,0,1,0"
 									Padding="0"
-									HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+									HorizontalAlignment="Stretch"
+									HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 									VerticalAlignment="Stretch"
 									VerticalContentAlignment="Center"
 									AcceptsReturn="False"


### PR DESCRIPTION
I notice that
1. we may focus the cursor to the PART_Measuring_Element  some time while the length of PART_TextBox is less than PART_Measuring_Element 

2. also, we could not focus to PART_Measuring_Element  if we are not clicking the value text.

this pr:
1. fix 1
2. fix 2 and make ux better
