### PR TITLE
Revert "Fix #1: FormatString not working with custom texts, Fix #2: Control not scaling correctly with HorizontalAlignment set to "Stretch""

### DIFF
--- a/source/Demo/UpDownDemoLib/ViewModels/DoubleUpDownViewModel.cs
+++ b/source/Demo/UpDownDemoLib/ViewModels/DoubleUpDownViewModel.cs
@@ -29,8 +29,6 @@
             base.MaximumValue = maximumValue;
             base.StepSize = stepSize;
             base.LargeStepSize = largestepSize;
-
-            FormatString = "F4";
         }
 
         /// Method determine whether two objects of type {T} are equal.

--- a/source/Demo/UpDownDemoLib/ViewModels/FloatUpDownViewModel.cs
+++ b/source/Demo/UpDownDemoLib/ViewModels/FloatUpDownViewModel.cs
@@ -29,8 +29,6 @@
             base.MaximumValue = maximumValue;
             base.StepSize = stepSize;
             base.LargeStepSize = largeStepSize;
-
-            FormatString = "F4";
         }
 
         /// Method determine whether two objects of type {T} are equal.

--- a/source/Demo/UpDownDemoLib/Views/ByteUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/ByteUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,7 +27,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
@@ -44,9 +43,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-   <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-   <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -259,20 +259,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/DecimalUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/DecimalUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,11 +27,10 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="10"
-            FormatString="{Binding FormatString, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
@@ -44,9 +42,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -251,20 +250,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/DoubleUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/DoubleUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,11 +27,11 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="7"
-            FormatString="{Binding FormatString, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+			FormatString="F4"
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
@@ -44,9 +43,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-        
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -248,19 +248,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/FloatUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/FloatUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,11 +27,10 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
-            FormatString="{Binding FormatString, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
@@ -44,9 +42,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -251,19 +250,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/LongUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/LongUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,8 +27,8 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
-            VerticalAlignment="Top"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
 			FormatString="{Binding FormatString, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
@@ -45,9 +44,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -230,47 +230,35 @@
 							ToolTip="Toggles whether a validation indicator is shown in the upper left corner of the control." />
 					</StackPanel>
 
-                    <Border
+					<Border
 						Margin="0,3"
 						BorderBrush="Gray"
 						BorderThickness="1">
-                        <StackPanel xmlns:input="System.Windows.Input" Margin="3">
-                            <StackPanel.Resources>
-                                <conv:EnumMatchToBooleanConverter x:Key="enumConverter" />
-                            </StackPanel.Resources>
+						<StackPanel xmlns:input="System.Windows.Input" Margin="3">
+							<StackPanel.Resources>
+								<conv:EnumMatchToBooleanConverter x:Key="enumConverter" />
+							</StackPanel.Resources>
 
 
-                            <TextBlock Margin="3" Text="Press this key to accelerate increments/decrements when scrolling with mouse wheel." />
+							<TextBlock Margin="3" Text="Press this key to accelerate increments/decrements when scrolling with mouse wheel." />
 
-                            <RadioButton
+							<RadioButton
 								Margin="3"
 								Content="Alt"
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Alt}" />
 
-                            <RadioButton
+							<RadioButton
 								Margin="3"
 								Content="Control"
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Control}" />
 
-                            <RadioButton
+							<RadioButton
 								Margin="3"
 								Content="Shift"
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
-                        </StackPanel>
-                    </Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+						</StackPanel>
+					</Border>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/NumericUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/NumericUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,7 +27,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
@@ -45,9 +44,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-        
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -258,21 +258,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-							<Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-
-                        </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/PercentageUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/PercentageUpDownDemo.xaml
@@ -20,8 +20,7 @@
 		</Grid.Resources>
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -33,11 +32,10 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="7"
-            FormatString="{Binding FormatString, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
@@ -49,9 +47,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Converter={StaticResource FactorToDoubleConverter}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<GroupBox Header="Debugging Values">
 				<StackPanel>
 					<Grid>
@@ -376,19 +375,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/SByteUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/SByteUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,7 +27,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
@@ -45,9 +44,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -259,19 +259,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/ShortUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/ShortUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,7 +27,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
@@ -45,9 +44,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -259,19 +259,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/UIntegerUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/UIntegerUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -29,7 +28,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="10"
@@ -46,9 +45,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -260,19 +260,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/ULongUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/ULongUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -28,7 +27,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
@@ -45,9 +44,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-    <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -259,19 +259,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/Demo/UpDownDemoLib/Views/UShortUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/UShortUpDownDemo.xaml
@@ -15,8 +15,7 @@
 		Grid.ColumnSpan="2">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
@@ -27,7 +26,7 @@
 			Grid.Column="0"
 			Grid.ColumnSpan="2"
 			Margin="3"
-			HorizontalAlignment="Stretch"
+			HorizontalAlignment="Left"
 			VerticalAlignment="Top"
 			HorizontalContentAlignment="{Binding HzntalContentAlignment}"
 			DisplayLength="5"
@@ -44,9 +43,10 @@
 			ToolTip="{Binding ToolTip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-     <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
-
-     <Grid Grid.Column="2" Margin="12,3,3,3">
+		<Grid
+			Grid.Row="1"
+			Grid.Column="1"
+			Margin="12,3,3,3">
 			<Grid.Resources>
 				<conv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 			</Grid.Resources>
@@ -258,19 +258,7 @@
 								IsChecked="{Binding Path=AccelModifierKey, Mode=TwoWay, Converter={StaticResource enumConverter}, ConverterParameter=Shift}" />
 						</StackPanel>
 					</Border>
-                    <Border
-                        Margin="0,3"
-                        BorderBrush="Gray"
-                        BorderThickness="1">
-                        <StackPanel Margin="3">
-
-                            <Label Content="FormatString" />
-                            <TextBox Text="{Binding FormatString}" />
-
-                        </StackPanel>
-
-                    </Border>
-                </StackPanel>
+				</StackPanel>
 			</GroupBox>
 		</Grid>
 	</Grid>

--- a/source/NumericUpDownLib/Base/AbstractBaseUpDown.cs
+++ b/source/NumericUpDownLib/Base/AbstractBaseUpDown.cs
@@ -703,15 +703,15 @@ namespace NumericUpDownLib.Base
 				}
 			}
 		}
-		
-        #region IsMouseDragEnabled
-        /// <summary>
-        /// Is invoked when <see cref="IsMouseDragEnabled"/> dependency property value
-        /// has been changed to update all states accordingly.
-        /// </summary>
-        /// <param name="d"></param>
-        /// <param name="e"></param>
-        private static void OnIsMouseDragEnabledChanged(DependencyObject d,
+
+		#region IsMouseDragEnabled
+		/// <summary>
+		/// Is invoked when <see cref="IsMouseDragEnabled"/> dependency property value
+		/// has been changed to update all states accordingly.
+		/// </summary>
+		/// <param name="d"></param>
+		/// <param name="e"></param>
+		private static void OnIsMouseDragEnabledChanged(DependencyObject d,
 														DependencyPropertyChangedEventArgs e)
 		{
 			(d as AbstractBaseUpDown<T>).OnIsMouseDragEnabledChanged(e);
@@ -1139,29 +1139,15 @@ namespace NumericUpDownLib.Base
 		}
 
 
-        /// <summary>
-        /// Gets a formatted string for the value of the number passed in
-        /// and ensures that a default string is returned even if there is
-        /// no format specified.
-        /// </summary>
-        /// <param name="number">.Net type specific value to be formated as string</param>
-        /// <returns>The string that was formatted with the FormatString
-        /// dependency property</returns>
-        protected string FormatNumber(T number)
-        {
-            string format = "{0}";
-            var form = (string) GetValue(FormatStringProperty);
-            if (string.IsNullOrEmpty(this.FormatString) == false)
-            {
-                format = !FormatString.StartsWith("{")
-                    ? "{0:" + this.FormatString + "}"
-                    : FormatString;
-            }
+		/// <summary>
+		/// format number value into string with formatstyle
+		/// </summary>
+		/// <param name="number"></param>
+		/// <returns></returns>
+		protected abstract string FormatNumber(T number);
 
-            return string.Format(format, number);
-        }
 
-        /// <summary>
+		/// <summary>
 		/// Checks if the current string entered in the textbox is:
 		/// 1) A valid number (syntax)
 		/// 2) within bounds (Min &lt;= number &lt;= Max )

--- a/source/NumericUpDownLib/Base/InputBaseUpDown.xaml
+++ b/source/NumericUpDownLib/Base/InputBaseUpDown.xaml
@@ -6,6 +6,8 @@
 	xmlns:local="clr-namespace:NumericUpDownLib.Base">
 
 	<Style x:Key="InputBaseUpDownStyle" TargetType="{x:Type local:InputBaseUpDown}">
+		<Setter Property="HorizontalAlignment" Value="Center" />
+		<Setter Property="VerticalAlignment" Value="Center" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type local:InputBaseUpDown}">
@@ -69,7 +71,7 @@
 
 								<TextBlock
 									Margin="3,0"
-									HorizontalAlignment="Stretch"
+									HorizontalAlignment="Left"
 									VerticalAlignment="Top"
 									Background="#00ffffff"
 									Foreground="{TemplateBinding EditingColorBrush}"
@@ -82,7 +84,7 @@
 								x:Name="PART_IncrementButton"
 								Grid.Row="0"
 								Grid.Column="1"
-								HorizontalAlignment="Right"
+								HorizontalAlignment="Left"
 								ClickCommand="{x:Static local:InputBaseUpDown.IncreaseCommand}"
 								RepeatButtonContent="M 0 4 L 6 4 L 3 0 Z"
 								Visibility="{Binding Path=IsIncDecButtonsVisible, RelativeSource={RelativeSource AncestorType={x:Type local:InputBaseUpDown}}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisibilityConverter}}" />
@@ -92,7 +94,7 @@
 								x:Name="PART_DecrementButton"
 								Grid.Row="1"
 								Grid.Column="1"
-								HorizontalAlignment="Right"
+								HorizontalAlignment="Left"
 								ClickCommand="{x:Static local:InputBaseUpDown.DecreaseCommand}"
 								RepeatButtonContent="M 0 0 L 3 4 L 6 0 Z"
 								Visibility="{Binding Path=IsIncDecButtonsVisible, RelativeSource={RelativeSource AncestorType={x:Type local:InputBaseUpDown}}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisibilityConverter}}" />

--- a/source/NumericUpDownLib/ByteUpDown.cs
+++ b/source/NumericUpDownLib/ByteUpDown.cs
@@ -381,6 +381,28 @@ namespace NumericUpDownLib
 			byte v = (byte)value;
 			return (v > 0);
 		}
-        #endregion methods
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(byte number)
+		{
+			string format = "{0}";
+
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
+		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/DecimalUpDown.cs
+++ b/source/NumericUpDownLib/DecimalUpDown.cs
@@ -381,6 +381,27 @@ namespace NumericUpDownLib
 			decimal v = (decimal)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(decimal number)
+		{
+			string format = "{0}";
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/DoubleUpDown.cs
+++ b/source/NumericUpDownLib/DoubleUpDown.cs
@@ -384,6 +384,27 @@ namespace NumericUpDownLib
 			double v = (double)value;
 			return (v > 0);
 		}
-        #endregion methods
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(double number)
+		{
+			string format = "{0}";
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
+		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/FloatUpDown.cs
+++ b/source/NumericUpDownLib/FloatUpDown.cs
@@ -383,6 +383,27 @@ namespace NumericUpDownLib
 			float v = (float)value;
 			return (v > 0);
 		}
-        #endregion methods
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(float number)
+		{
+			string format = "{0}";
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
+		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/LongUpDown.cs
+++ b/source/NumericUpDownLib/LongUpDown.cs
@@ -381,6 +381,26 @@ namespace NumericUpDownLib
 			return (v > 0);
 		}
 
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(long number)
+		{
+			string format = "{0}";
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/NumericUpDown.cs
+++ b/source/NumericUpDownLib/NumericUpDown.cs
@@ -380,6 +380,27 @@ namespace NumericUpDownLib
 			var v = (int)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(int number)
+		{
+			string format = "{0}";
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/SByteUpDown.cs
+++ b/source/NumericUpDownLib/SByteUpDown.cs
@@ -381,6 +381,28 @@ namespace NumericUpDownLib
 			var v = (sbyte)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(sbyte number)
+		{
+			string format = "{0}";
+
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/ShortUpDown.cs
+++ b/source/NumericUpDownLib/ShortUpDown.cs
@@ -380,6 +380,28 @@ namespace NumericUpDownLib
 			var v = (short)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(short number)
+		{
+			string format = "{0}";
+
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/UIntegerUpDown.cs
+++ b/source/NumericUpDownLib/UIntegerUpDown.cs
@@ -380,6 +380,28 @@ namespace NumericUpDownLib
 			var v = (uint)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(uint number)
+		{
+			string format = "{0}";
+
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/ULongUpDown.cs
+++ b/source/NumericUpDownLib/ULongUpDown.cs
@@ -380,6 +380,28 @@ namespace NumericUpDownLib
 			var v = (ulong)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(ulong number)
+		{
+			string format = "{0}";
+
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }

--- a/source/NumericUpDownLib/UShortUpDown.cs
+++ b/source/NumericUpDownLib/UShortUpDown.cs
@@ -381,6 +381,27 @@ namespace NumericUpDownLib
 			var v = (ushort)value;
 			return (v > 0);
 		}
+
+		/// <summary>
+		/// Gets a formatted string for the value of the number passed in
+		/// and ensures that a default string is returned even if there is
+		/// no format specified.
+		/// </summary>
+		/// <param name="number">.Net type specific value to be formated as string</param>
+		/// <returns>The string that was formatted with the FormatString
+		/// dependency property</returns>
+		protected override string FormatNumber(ushort number)
+		{
+			string format = "{0}";
+			LastEditingNumericValue = number;
+
+			var form = (string)GetValue(FormatStringProperty);
+
+			if (string.IsNullOrEmpty(this.FormatString) == false)
+				format = "{0:" + this.FormatString + "}";
+
+			return string.Format(format, number);
+		}
 		#endregion methods
 	}
 }


### PR DESCRIPTION
Reverts Dirkster99/NumericUpDownLib#50

@jholzer
I Had to revert PR #50 since I found in later testing that the demo client now throws an exception when the user switches the tab from Byte to Decimal :-(

Could please fix this and test more carefully?

Thanks for the effort.

![image](https://user-images.githubusercontent.com/2129700/197021787-a139aa09-be6b-455b-aaf5-eb53c5e37447.png)

Details:
```
System.FormatException
  HResult=0x80131537
  Message=Format specifier was invalid.
  Source=mscorlib
  StackTrace:
   at System.Number.FormatDecimal(Decimal value, String format, NumberFormatInfo info)
   at System.Decimal.ToString(String format, IFormatProvider provider)
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(String format, Object arg0)
   at NumericUpDownLib.Base.AbstractBaseUpDown`1.FormatNumber(T number) in F:\MyFiles\CSharp\00_GitHub\NumericUpDownLib\source\NumericUpDownLib\Base\AbstractBaseUpDown.cs:line 1161
   at NumericUpDownLib.DecimalUpDown.FormatText(String text, Boolean formatNumber) in F:\MyFiles\CSharp\00_GitHub\NumericUpDownLib\source\NumericUpDownLib\DecimalUpDown.cs:line 368
   at NumericUpDownLib.Base.AbstractBaseUpDown`1.OnApplyTemplate() in F:\MyFiles\CSharp\00_GitHub\NumericUpDownLib\source\NumericUpDownLib\Base\AbstractBaseUpDown.cs:line 633
   at System.Windows.FrameworkElement.ApplyTemplate()
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at System.Windows.Controls.Grid.MeasureCell(Int32 cell, Boolean forceInfinityV)
   at System.Windows.Controls.Grid.MeasureCellsGroup(Int32 cellsHead, Size referenceSize, Boolean ignoreDesiredSizeU, Boolean forceInfinityV, Boolean& hasDesiredSizeUChanged)
   at System.Windows.Controls.Grid.MeasureOverride(Size constraint)
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at MS.Internal.Helper.MeasureElementWithSingleChild(UIElement element, Size constraint)
   at System.Windows.Controls.ContentPresenter.MeasureOverride(Size constraint)
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at System.Windows.Controls.Border.MeasureOverride(Size constraint)
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at System.Windows.Controls.Control.MeasureOverride(Size constraint)
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at MS.Internal.Helper.MeasureElementWithSingleChild(UIElement element, Size constraint)
   at System.Windows.Controls.ContentPresenter.MeasureOverride(Size constraint)
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at System.Windows.ContextLayoutManager.UpdateLayout()
   at System.Windows.Controls.TabItem.OnPreviewGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.InputManager.ProcessInput(InputEventArgs input)
   at System.Windows.Input.KeyboardDevice.TryChangeFocus(DependencyObject newFocus, IKeyboardInputProvider keyboardInputProvider, Boolean askOld, Boolean askNew, Boolean forceToNullIfFailed)
   at System.Windows.Input.KeyboardDevice.Focus(DependencyObject focus, Boolean askOld, Boolean askNew, Boolean forceToNullIfFailed)
   at System.Windows.Input.KeyboardDevice.Focus(IInputElement element)
   at System.Windows.UIElement.Focus()
   at System.Windows.Controls.TabItem.SetFocus()
   at System.Windows.Controls.TabItem.OnMouseLeftButtonDown(MouseButtonEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.ReRaiseEventAs(DependencyObject sender, RoutedEventArgs args, RoutedEvent newEvent)
   at System.Windows.UIElement.OnMouseDownThunk(Object sender, MouseButtonEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.InputManager.ProcessInput(InputEventArgs input)
   at System.Windows.Input.InputProviderSite.ReportInput(InputReport inputReport)
   at System.Windows.Interop.HwndMouseInputProvider.ReportInput(IntPtr hwnd, InputMode mode, Int32 timestamp, RawMouseActions actions, Int32 x, Int32 y, Int32 wheel)
   at System.Windows.Interop.HwndMouseInputProvider.FilterMessage(IntPtr hwnd, WindowMessage msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at System.Windows.Interop.HwndSource.InputFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at TestGenerics.App.Main()

```
