### PR TITLE
Bugfix: Format-Text must return parsed value, else value in textbox will be overwritten with "LastEditingNumericValue" if "IsUpdateValueWhenLostFocus" is enabled on lost focus

### DIFF
--- a/source/Demo/UpDownDemoLib/Views/ByteUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/ByteUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"
 			MouseWheelAccelaratorKey="{Binding AccelModifierKey, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"

--- a/source/Demo/UpDownDemoLib/Views/DecimalUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/DecimalUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/DoubleUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/DoubleUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/FloatUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/FloatUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/LongUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/LongUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/NumericUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/NumericUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+			IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/PercentageUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/PercentageUpDownDemo.xaml
@@ -40,6 +40,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue, Converter={StaticResource FactorToDoubleConverter}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MinValue="{Binding MinimumValue, Converter={StaticResource FactorToDoubleConverter}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"

--- a/source/Demo/UpDownDemoLib/Views/SByteUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/SByteUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/ShortUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/ShortUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/UIntegerUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/UIntegerUpDownDemo.xaml
@@ -36,6 +36,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/ULongUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/ULongUpDownDemo.xaml
@@ -35,6 +35,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/Demo/UpDownDemoLib/Views/UShortUpDownDemo.xaml
+++ b/source/Demo/UpDownDemoLib/Views/UShortUpDownDemo.xaml
@@ -34,6 +34,7 @@
 			IsDisplayLengthFixed="True"
 			IsMouseDragEnabled="{Binding ElementName=IsMouseDragEnabledCheckBox, Path=IsChecked}"
 			IsReadOnly="False"
+            IsUpdateValueWhenLostFocus="True"
 			LargeStepSize="{Binding LargeStepSize, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
 			MaxValue="{Binding MaximumValue}"
 			MinValue="{Binding MinimumValue}"

--- a/source/NumericUpDownLib/Base/AbstractBaseUpDown.cs
+++ b/source/NumericUpDownLib/Base/AbstractBaseUpDown.cs
@@ -3,6 +3,7 @@ namespace NumericUpDownLib.Base
 	using NumericUpDownLib.Enums;
 	using NumericUpDownLib.Models;
 	using System;
+	using System.Globalization;
 	using System.Windows;
 	using System.Windows.Controls;
 	using System.Windows.Controls.Primitives;
@@ -1159,21 +1160,44 @@ namespace NumericUpDownLib.Base
         }
 
         /// <summary>
-		/// Checks if the current string entered in the textbox is:
-		/// 1) A valid number (syntax)
-		/// 2) within bounds (Min &lt;= number &lt;= Max )
-		///
-		/// 3) adjusts the string if it appears to be invalid and
-		///
-		/// 4) <paramref name="formatNumber"/> true:
-		///    Applies the FormatString property to format the text in a certain way
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		/// <returns>the value of the string with special format</returns>
-		protected abstract T FormatText(string text, bool formatNumber = true);
+        /// Checks if the current string entered in the textbox is:
+        /// 1) A valid number (syntax)
+        /// 2) within bounds (Min &lt;= number &lt;= Max )
+        ///
+        /// 3) adjusts the string if it appears to be invalid and
+        ///
+        /// 4) <paramref name="formatNumber"/> true:
+        ///    Applies the FormatString property to format the text in a certain way
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="formatNumber"></param>
+        /// <returns>the value of the string with special format</returns>
+        protected T FormatText(string text, bool formatNumber = true)
+        {
+            if (_PART_TextBox == null)
+                return Value;
 
-		/// <summary>
+            T number = default;
+            // Does this text represent a valid number ?
+            if (ParseText(text, out number))
+            {
+                number = CoerceValue(number);
+
+                _PART_TextBox.Text = FormatNumber(number);
+                _PART_TextBox.SelectionStart = 0;
+
+                return number;
+            }
+
+            // Reset to last value since string does not appear to represent a number
+            _PART_TextBox.SelectionStart = 0;
+            _PART_TextBox.Text = FormatNumber(Value);
+            return LastEditingNumericValue;
+        }
+
+        protected abstract bool ParseText(string text, out T number);
+
+        /// <summary>
 		/// Verify the text is valid or not while use is typing
 		/// </summary>
 		/// <param name="text"></param>

--- a/source/NumericUpDownLib/ByteUpDown.cs
+++ b/source/NumericUpDownLib/ByteUpDown.cs
@@ -321,62 +321,18 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override byte FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
+        protected override bool ParseText(string text, out byte number)
+        {
+            return byte.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
-			byte number = 0;
-			// Does this text represent a valid number ?
-			if (byte.TryParse(text, base.NumberStyle,
-							  CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
-
-		/// <summary>
-		/// Determines whether the step size in the <paramref name="value"/> parameter
-		/// is larger 0 (valid) or not.
-		/// </summary>
-		/// <param name="value">returns true for valid values, otherwise false.</param>
-		/// <returns></returns>
-		private static bool IsValidStepSizeReading(object value)
+        /// <summary>
+        /// Determines whether the step size in the <paramref name="value"/> parameter
+        /// is larger 0 (valid) or not.
+        /// </summary>
+        /// <param name="value">returns true for valid values, otherwise false.</param>
+        /// <returns></returns>
+        private static bool IsValidStepSizeReading(object value)
 		{
 			byte v = (byte)value;
 			return (v > 0);

--- a/source/NumericUpDownLib/DecimalUpDown.cs
+++ b/source/NumericUpDownLib/DecimalUpDown.cs
@@ -322,61 +322,18 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override decimal FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			decimal number = 0;
-			// Does this text represent a valid number ?
-			if (decimal.TryParse(text, base.NumberStyle,
-								 CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out decimal number)
+        {
+            return decimal.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
-		/// <summary>
-		/// Determines whether the step size in the <paramref name="value"/> parameter
-		/// is larger 0 (valid) or not.
-		/// </summary>
-		/// <param name="value">returns true for valid values, otherwise false.</param>
-		/// <returns></returns>
-		private static bool IsValidStepSizeReading(object value)
+        /// <summary>
+        /// Determines whether the step size in the <paramref name="value"/> parameter
+        /// is larger 0 (valid) or not.
+        /// </summary>
+        /// <param name="value">returns true for valid values, otherwise false.</param>
+        /// <returns></returns>
+        private static bool IsValidStepSizeReading(object value)
 		{
 			decimal v = (decimal)value;
 			return (v > 0);

--- a/source/NumericUpDownLib/DoubleUpDown.cs
+++ b/source/NumericUpDownLib/DoubleUpDown.cs
@@ -325,53 +325,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override double FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			double number = 0;
-			// Does this text represent a valid number ?
-			if (double.TryParse(text, base.NumberStyle,
-								CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out double number)
+        {
+            return double.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/FloatUpDown.cs
+++ b/source/NumericUpDownLib/FloatUpDown.cs
@@ -324,53 +324,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override float FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			float number = 0;
-			// Does this text represent a valid number ?
-			if (float.TryParse(text, base.NumberStyle,
-								CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out float number)
+        {
+            return float.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/LongUpDown.cs
+++ b/source/NumericUpDownLib/LongUpDown.cs
@@ -321,53 +321,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override long FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			long number = 0;
-			// Does this text represent a valid number ?
-			if (long.TryParse(text, base.NumberStyle,
-							 CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out long number)
+        {
+            return long.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/NumericUpDown.cs
+++ b/source/NumericUpDownLib/NumericUpDown.cs
@@ -4,6 +4,7 @@ namespace NumericUpDownLib
 	using System;
 	using System.Globalization;
 	using System.Windows;
+	using static System.Net.Mime.MediaTypeNames;
 
 	/// <summary>
 	/// Implements an Integer based Numeric Up/Down control.
@@ -321,61 +322,18 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override int FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			int number = 0;
-			// Does this text represent a valid number ?
-			if (int.TryParse(text, base.NumberStyle,
-							 CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out int number)
+        {
+            return int.TryParse(text, NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
-		/// <summary>
-		/// Determines whether the step size in the <paramref name="value"/> parameter
-		/// is larger 0 (valid) or not.
-		/// </summary>
-		/// <param name="value">returns true for valid values, otherwise false.</param>
-		/// <returns></returns>
-		private static bool IsValidStepSizeReading(object value)
+        /// <summary>
+        /// Determines whether the step size in the <paramref name="value"/> parameter
+        /// is larger 0 (valid) or not.
+        /// </summary>
+        /// <param name="value">returns true for valid values, otherwise false.</param>
+        /// <returns></returns>
+        private static bool IsValidStepSizeReading(object value)
 		{
 			var v = (int)value;
 			return (v > 0);

--- a/source/NumericUpDownLib/SByteUpDown.cs
+++ b/source/NumericUpDownLib/SByteUpDown.cs
@@ -321,54 +321,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override SByte FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-
-			sbyte number = 0;
-			// Does this text represent a valid number ?
-			if (sbyte.TryParse(text, base.NumberStyle,
-							   CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out SByte number)
+        {
+            return SByte.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/ShortUpDown.cs
+++ b/source/NumericUpDownLib/ShortUpDown.cs
@@ -321,53 +321,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override short FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			short number = 0;
-			// Does this text represent a valid number ?
-			if (short.TryParse(text, base.NumberStyle,
-							  CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out short number)
+        {
+            return short.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/UIntegerUpDown.cs
+++ b/source/NumericUpDownLib/UIntegerUpDown.cs
@@ -321,53 +321,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override uint FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			uint number = 0;
-			// Does this text represent a valid number ?
-			if (uint.TryParse(text, base.NumberStyle,
-							 CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out uint number)
+        {
+            return uint.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/ULongUpDown.cs
+++ b/source/NumericUpDownLib/ULongUpDown.cs
@@ -321,53 +321,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override ulong FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			ulong number = 0;
-			// Does this text represent a valid number ?
-			if (ulong.TryParse(text, base.NumberStyle,
-							 CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out ulong number)
+        {
+            return ulong.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter

--- a/source/NumericUpDownLib/UShortUpDown.cs
+++ b/source/NumericUpDownLib/UShortUpDown.cs
@@ -321,54 +321,10 @@ namespace NumericUpDownLib
 			return false;
 		}
 
-		/// <summary>
-		/// Checks if the current string entered in the textbox is valid
-		/// and conforms to a known format
-		/// (<see cref="AbstractBaseUpDown{T}"/> base method for more details).
-		/// </summary>
-		/// <param name="text"></param>
-		/// <param name="formatNumber"></param>
-		protected override ushort FormatText(string text, bool formatNumber = true)
-		{
-			if (_PART_TextBox == null)
-				return Value;
-			ushort number = 0;
-			// Does this text represent a valid number ?
-			if (ushort.TryParse(text, base.NumberStyle,
-							  CultureInfo.CurrentCulture, out number) == true)
-			{
-				// yes -> but is the number within bounds?
-				if (number > MaxValue)
-				{
-					// Larger than allowed maximum
-					_PART_TextBox.Text = FormatNumber(MaxValue);
-					_PART_TextBox.SelectionStart = 0;
-				}
-				else
-				{
-					if (number < MinValue)
-					{
-						// Smaller than allowed minimum
-						_PART_TextBox.Text = FormatNumber(MinValue);
-						_PART_TextBox.SelectionStart = 0;
-					}
-					else
-					{
-						// Number is valid and within bounds, just format if requested
-						if (formatNumber == true)
-							_PART_TextBox.Text = FormatNumber(number);
-					}
-				}
-			}
-			else
-			{
-				// Reset to last value since string does not appear to represent a number
-				_PART_TextBox.SelectionStart = 0;
-				_PART_TextBox.Text = FormatNumber(Value);
-				number = Value;
-			}
-			return LastEditingNumericValue;
-		}
+        protected override bool ParseText(string text, out ushort number)
+        {
+            return ushort.TryParse(text, base.NumberStyle, CultureInfo.CurrentCulture, out number);
+        }
 
 		/// <summary>
 		/// Determines whether the step size in the <paramref name="value"/> parameter


### PR DESCRIPTION
- Consolidate "FormatText" in base class (it´s nearly the same code in all derived classes)
- introduce abstract "ParseText" and type specific implementations for usage in "FormatText", which was the only difference in the several implementations
- return parsed value in "FormatText" to be used in e.g. _PART_TextBox_LostFocus, where it is assgined to "Value" (here´s were "Value" got lost)
- activate "IsUpdateValueWhenLostFocus" in demo application

Steps to reproduce in original version:

- enable "IsUpdateValueWhenLostFocus" in WPF-code for NumericUpDown
- any value (except 0) is visible in numeric up down control
- click into text field of numeric up down control
- press tab

Expected behavior: value does not change
Observed behavior: value changes to LastEditingNumericValue, in example: "0"